### PR TITLE
feat: add Claude Code scaffold implementations

### DIFF
--- a/impl-1/.claude/settings.json
+++ b/impl-1/.claude/settings.json
@@ -1,0 +1,20 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm run test:)",
+      "Bash(git diff:)",
+      "Read(./*.md)",
+      "Read(./*.json)"
+    ],
+    "ask": [
+      "Bash(git push:)",
+      "Write(/)"
+    ],
+    "deny": [
+      "Bash(curl:)",
+      "Read(./.env)",
+      "Read(./.env.*)",
+      "Read(./secrets/)"
+    ]
+  }
+}

--- a/impl-1/CLAUDE.md
+++ b/impl-1/CLAUDE.md
@@ -1,0 +1,12 @@
+Goal: Minimal, auditable Claude Code env with small diffs & TDD.
+
+DoD: See README.
+
+Commands
+- Tests (example): `echo '{}' | jq .` (placeholder until real tests exist)
+- Doctor: `claude doctor`
+
+Heuristics
+- Explore → Plan → Code → Commit
+- TDD first; smallest diff
+- Ask on push; deny secrets

--- a/impl-1/README.md
+++ b/impl-1/README.md
@@ -1,0 +1,24 @@
+impl-1 — Claude Code via Native Installer (latest)
+
+Quickstart
+
+```bash
+bash scripts/install.sh
+claude --version
+claude -p 'say hello' --output-format json
+```
+
+Workflow (Explore → Plan → Code → Commit)
+1. Explore: "Read tests/ and summarize constraints. Do not edit files."
+2. Plan: "Propose smallest diff to pass a test; include risks + rollback."
+3. Code: "Write/adjust tests first, run them, then minimal code to pass."
+4. Commit: "Show git diff --stat, write scoped commit, then commit."
+
+DoD
+- Install succeeds; claude doctor OK.
+- Permissions: tests/read auto-allow; pushes ask; secrets denied.
+- Headless sample works: `claude -p 'ping' --output-format json`.
+
+Rollback
+
+If an autonomous run misfires: `git reset --hard <last_good>` and retry with a simpler plan. Safe-YOLO is discouraged outside sandboxes.

--- a/impl-1/scripts/check.sh
+++ b/impl-1/scripts/check.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[impl-1] Smoke test..."
+claude --version
+claude -p 'ping' --output-format json >/tmp/impl-1-smoke.json
+cat /tmp/impl-1-smoke.json
+rm /tmp/impl-1-smoke.json
+echo "[impl-1] OK"

--- a/impl-1/scripts/install.sh
+++ b/impl-1/scripts/install.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[impl-1] Installing Claude Code (native, latest)..."
+if command -v claude >/dev/null 2>&1; then
+  echo "[impl-1] claude already installed: $(claude --version)"
+  exit 0
+fi
+case "$OSTYPE" in
+  darwin*|linux-gnu*|linux-musl*)
+    curl -fsSL https://claude.ai/install.sh | bash
+    ;;
+  *)
+    echo "[impl-1] Unsupported OS for native installer. Install manually."
+    exit 1
+    ;;
+esac
+echo "[impl-1] Verifying..."
+claude --version
+echo "[impl-1] Done."

--- a/impl-2/.claude/settings.json
+++ b/impl-2/.claude/settings.json
@@ -1,0 +1,20 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm run test:)",
+      "Bash(git diff:)",
+      "Read(./*.md)",
+      "Read(./*.json)"
+    ],
+    "ask": [
+      "Bash(git push:)",
+      "Write(/)"
+    ],
+    "deny": [
+      "Bash(curl:)",
+      "Read(./.env)",
+      "Read(./.env.*)",
+      "Read(./secrets/)"
+    ]
+  }
+}

--- a/impl-2/CLAUDE.md
+++ b/impl-2/CLAUDE.md
@@ -1,0 +1,2 @@
+Pinning: Respect CLAUDE_CODE_VERSION. If not set, install latest.
+Heuristics: same as impl-1.

--- a/impl-2/README.md
+++ b/impl-2/README.md
@@ -1,0 +1,13 @@
+impl-2 — Claude Code via Native Installer (pinned)
+
+Pin a version via CLAUDE_CODE_VERSION (e.g., `export CLAUDE_CODE_VERSION=2.1.0`).
+
+Quickstart
+
+```bash
+export CLAUDE_CODE_VERSION=2.1.0   # optional; defaults to latest
+bash scripts/install.sh
+claude --version
+```
+
+Other workflow/DoD/rollback: identical to impl-1.

--- a/impl-2/scripts/check.sh
+++ b/impl-2/scripts/check.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[impl-2] Smoke test..."
+claude --version
+claude -p 'ping' --output-format json >/tmp/impl-2-smoke.json
+cat /tmp/impl-2-smoke.json
+rm /tmp/impl-2-smoke.json
+echo "[impl-2] OK"

--- a/impl-2/scripts/install.sh
+++ b/impl-2/scripts/install.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VER="${CLAUDE_CODE_VERSION:-}"
+
+echo "[impl-2] Installing Claude Code (native, pinned=${VER:-latest})..."
+if command -v claude >/dev/null 2>&1; then
+  echo "[impl-2] claude already installed: $(claude --version)"
+  exit 0
+fi
+case "$OSTYPE" in
+  darwin*|linux-gnu*|linux-musl*)
+    if [ -n "$VER" ]; then
+      curl -fsSL https://claude.ai/install.sh | bash -s "$VER"
+    else
+      curl -fsSL https://claude.ai/install.sh | bash
+    fi
+    ;;
+  *)
+    echo "[impl-2] Unsupported OS for native installer."
+    exit 1
+    ;;
+esac
+claude --version
+echo "[impl-2] Done."

--- a/impl-3/.claude/settings.json
+++ b/impl-3/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm run test:)",
+      "Bash(git diff:)",
+      "Read(/)"
+    ],
+    "ask": [
+      "Bash(git push:)"
+    ],
+    "deny": [
+      "Bash(curl:)",
+      "Read(./.env)",
+      "Read(./.env.)",
+      "Read(./secrets/)"
+    ]
+  }
+}

--- a/impl-3/.github/workflows/claude-headless.yml
+++ b/impl-3/.github/workflows/claude-headless.yml
@@ -1,0 +1,26 @@
+name: Claude Headless Review
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code
+      - name: Run headless review (read-only)
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          set -e
+          claude -p "Read the diff and emit a JSON with {style_issues:[], risks:[], summary:''}. No code changes." --output-format json | tee review.json
+      - name: Upload JSON artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-review
+          path: review.json

--- a/impl-3/CLAUDE.md
+++ b/impl-3/CLAUDE.md
@@ -1,0 +1,2 @@
+Headless review: `claude -p "<review prompt>" --output-format json` in CI.
+Heuristics: small diffs; TDD; ask on push; deny secrets.

--- a/impl-3/README.md
+++ b/impl-3/README.md
@@ -1,0 +1,16 @@
+impl-3 — npm global + CI headless
+
+Installs Claude Code via npm and adds a headless CI that runs a read-only JSON review on PRs.
+
+Quickstart
+
+```bash
+bash scripts/install.sh
+claude -p "ping" --output-format json
+```
+
+CI
+- See .github/workflows/claude-headless.yml
+- Emits a JSON artifact; does not fail builds by default.
+
+Other workflow/DoD/rollback: same as impl-1.

--- a/impl-3/scripts/check.sh
+++ b/impl-3/scripts/check.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[impl-3] Smoke test..."
+claude --version
+claude -p 'ping' --output-format json >/tmp/impl-3-smoke.json
+cat /tmp/impl-3-smoke.json
+rm /tmp/impl-3-smoke.json
+echo "[impl-3] OK"

--- a/impl-3/scripts/install.sh
+++ b/impl-3/scripts/install.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[impl-3] Installing Claude Code via npm..."
+if command -v claude >/dev/null 2>&1; then
+  echo "[impl-3] claude already installed: $(claude --version)"
+  exit 0
+fi
+if ! command -v npm >/dev/null 2>&1; then
+  echo "[impl-3] npm not found. Install Node 18+ first."
+  exit 1
+fi
+npm install -g @anthropic-ai/claude-code
+claude --version
+echo "[impl-3] Done."

--- a/impl-4/.claude/settings.json
+++ b/impl-4/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm run test:)",
+      "Bash(git diff:)",
+      "Read(/)"
+    ],
+    "ask": [
+      "Bash(git push:)",
+      "Write(/)"
+    ],
+    "deny": [
+      "Bash(curl:)",
+      "Read(./.env)",
+      "Read(./.env.*)",
+      "Read(./secrets/**)"
+    ]
+  }
+}

--- a/impl-4/CLAUDE.md
+++ b/impl-4/CLAUDE.md
@@ -1,0 +1,2 @@
+Sandboxed automation: Use auto-accept only inside the container/agent.
+Heuristics: same as other impls; keep diffs small; TDD; ask on push; deny secrets.

--- a/impl-4/README.md
+++ b/impl-4/README.md
@@ -1,0 +1,12 @@
+impl-4 — Remote Workspace (choose one: Devcontainer or Coder)
+
+Pick the subfolder you use (devcontainer/ or coder/).
+
+Devcontainer
+- Open the folder in VS Code → Reopen in Container.
+- Claude Code is installed at build time inside the container.
+- Safe-YOLO note: Auto-accept is allowed here only (disposable env).
+
+Coder
+- Push the template (coder/main.tf) with `coder templates push`.
+- Create a workspace; provide API key via a secure parameter.

--- a/impl-4/coder/main.tf
+++ b/impl-4/coder/main.tf
@@ -1,0 +1,35 @@
+terraform {
+  required_providers { coder = { source = "coder/coder" } }
+}
+provider "coder" {}
+
+data "coder_workspace" "me" {}
+data "coder_provisioner" "me" {}
+
+data "coder_parameter" "anthropic_api_key" {
+  name         = "anthropic_api_key"
+  display_name = "Anthropic API key"
+  description  = "Provide an API key from console.anthropic.com"
+  sensitive    = true
+}
+
+resource "coder_agent" "dev" {
+  os   = "linux"
+  arch = data.coder_provisioner.me.arch
+  env  = { ANTHROPIC_API_KEY = data.coder_parameter.anthropic_api_key.value }
+  startup_script = <<-EOT
+set -euxo pipefail
+if ! command -v claude >/dev/null 2>&1; then
+  curl -fsSL https://claude.ai/install.sh | bash
+fi
+claude --version || true
+EOT
+}
+
+module "claude_code" {
+  source   = "registry.coder.com/coder/claude-code/coder"
+  version  = "2.1.0"
+  agent_id = coder_agent.dev.id
+  folder   = "/home/coder/project"
+  install_claude_code = false
+}

--- a/impl-4/devcontainer/Dockerfile
+++ b/impl-4/devcontainer/Dockerfile
@@ -1,0 +1,10 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
+SHELL ["/bin/bash", "-lc"]
+RUN apt-get update && apt-get install -y curl git ca-certificates && rm -rf /var/lib/apt/lists/*
+
+# Install Node (for npm fallback/tools)
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && apt-get install -y nodejs
+
+# Install Claude Code (native latest)
+RUN curl -fsSL https://claude.ai/install.sh | bash
+RUN claude --version || true

--- a/impl-4/devcontainer/devcontainer.json
+++ b/impl-4/devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "claude-code-sandbox",
+  "build": { "dockerfile": "Dockerfile" },
+  "features": {},
+  "remoteUser": "vscode",
+  "postCreateCommand": "claude --version || true",
+  "customizations": {
+    "vscode": {
+      "settings": {},
+      "extensions": []
+    }
+  }
+}

--- a/impl-4/scripts/check.sh
+++ b/impl-4/scripts/check.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[impl-4] Smoke test..."
+claude --version
+claude -p 'ping' --output-format json >/tmp/impl-4-smoke.json
+cat /tmp/impl-4-smoke.json
+rm /tmp/impl-4-smoke.json
+echo "[impl-4] OK"

--- a/impl-4/scripts/install.sh
+++ b/impl-4/scripts/install.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[impl-4] Checking Claude Code installation..."
+if ! command -v claude >/dev/null 2>&1; then
+  echo "[impl-4] claude not found; installing (native, latest)..."
+  case "$OSTYPE" in
+    darwin*|linux-gnu*|linux-musl*)
+      curl -fsSL https://claude.ai/install.sh | bash
+      ;;
+    *)
+      echo "[impl-4] Unsupported OS."
+      exit 1
+      ;;
+  esac
+fi
+claude --version
+echo "[impl-4] Done."


### PR DESCRIPTION
## Summary
- add four installation strategies for Claude Code CLI (native latest, native pinned, npm global with CI review, remote workspace via devcontainer or Coder)
- include permissions, docs, and smoke-test scripts for each scaffold

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a766066fa483219810fbd3a435998c

---
## EntelligenceAI PR Summary 
 This PR adds four distinct Claude code environment implementations with:
- Structured permissions via .claude/settings.json in each impl-*
- Project documentation (README.md, CLAUDE.md) for setup, workflow, and security
- Automated install and check scripts for the 'claude' CLI
- CI workflow for headless code review in impl-3
- Remote workspace provisioning (Terraform, devcontainer) in impl-4 

