### PR TITLE
feat: add Hugging Face inference helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,17 @@ Continue building your app on:
 2. Deploy your chats from the v0 interface
 3. Changes are automatically pushed to this repository
 4. Vercel deploys the latest version from this repository
+
+## Hugging Face Inference Provider
+
+The project now includes a helper for calling Hugging Face's OpenAI-compatible Inference API. Set the `HF_TOKEN` environment variable and use the `streamHuggingFace` function from `lib/huggingface.ts` to generate completions:
+
+```ts
+import { streamHuggingFace } from "@/lib/huggingface";
+
+const output = await streamHuggingFace([
+  { role: "user", content: "What is the capital of France?" },
+]);
+```
+
+This utility streams the response and returns the full text once complete.

--- a/lib/huggingface.ts
+++ b/lib/huggingface.ts
@@ -1,0 +1,53 @@
+const HF_API_URL = "https://router.huggingface.co/v1";
+
+export interface ChatMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+export async function streamHuggingFace(
+  messages: ChatMessage[],
+  model = "openai/gpt-oss-120b:groq",
+) {
+  const response = await fetch(`${HF_API_URL}/chat/completions`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${process.env.HF_TOKEN}`,
+    },
+    body: JSON.stringify({ model, messages, stream: true }),
+  });
+
+  if (!response.body) {
+    throw new Error("No response body");
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let full = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    const chunk = decoder.decode(value, { stream: true });
+    for (const line of chunk.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith("data:")) continue;
+      const data = trimmed.slice(5).trim();
+      if (data === "[DONE]") {
+        return full;
+      }
+      try {
+        const json = JSON.parse(data);
+        const content = json.choices?.[0]?.delta?.content;
+        if (content) {
+          full += content;
+        }
+      } catch {
+        // ignore malformed JSON lines
+      }
+    }
+  }
+
+  return full;
+}


### PR DESCRIPTION
## Summary
- add helper for Hugging Face's OpenAI-compatible inference API
- document usage of the new helper in README

## Testing
- `pnpm lint` *(fails: Next.js ESLint plugin warning)*
- `pnpm build` *(fails: cannot fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a76ccc10008321ad36ad373e5b9cc1