### PR TITLE
Add knowledge catalog schema and sample queries

### DIFF
--- a/kb/catalog.schema.json
+++ b/kb/catalog.schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Knowledge Base Catalog Item",
+  "type": "object",
+  "required": ["id", "title", "artifact_type"],
+  "properties": {
+    "id": {"type": "string"},
+    "title": {"type": "string"},
+    "artifact_type": {
+      "type": "string",
+      "enum": [
+        "link", "code-snippet", "repo", "prompt", "note",
+        "dataset", "paper", "tool", "decision", "experiment",
+        "pattern", "checklist", "task"
+      ]
+    },
+    "capability": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "rag", "agents", "evals", "retrieval", "orchestration",
+          "vision", "audio", "UI", "devops", "growth", "data",
+          "security", "legal", "monetization"
+        ]
+      },
+      "uniqueItems": true
+    },
+    "task": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "scaffold_microservice", "add_eval", "scrape_and_clean",
+          "trend_scan", "write_spec", "set_up_ci", "benchmark_model",
+          "deploy_vercel", "make_dashboard", "growth_tear_down",
+          "UX_wireframe"
+        ]
+      },
+      "uniqueItems": true
+    },
+    "stack": {
+      "type": "object",
+      "properties": {
+        "lang": {"type": "string"},
+        "runtime": {"type": "string"},
+        "cloud": {"type": "string"},
+        "db": {"type": "string"},
+        "vec": {"type": "string"},
+        "llm": {"type": "string"}
+      },
+      "additionalProperties": false
+    },
+    "maturity": {
+      "type": "string",
+      "enum": ["idea", "draft", "tried", "tested", "productionized"]
+    },
+    "last_verified_at": {"type": "string", "format": "date"},
+    "evidence": {
+      "type": "object",
+      "properties": {
+        "p_conf": {"type": "number", "minimum": 0, "maximum": 1},
+        "benchmarks": {"type": "array", "items": {"type": "string"}},
+        "passes": {"type": "integer", "minimum": 0},
+        "perf_notes": {"type": "string"},
+        "cost_est": {"type": "string"},
+        "failure_modes": {
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      },
+      "additionalProperties": false
+    },
+    "operability": {
+      "type": "object",
+      "properties": {
+        "how_to_run": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "deps": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "license": {"type": "string"}
+      },
+      "additionalProperties": false
+    },
+    "edges": {
+      "type": "object",
+      "properties": {
+        "depends_on": {"type": "array", "items": {"type": "string"}},
+        "supersedes": {"type": "array", "items": {"type": "string"}},
+        "supports": {"type": "array", "items": {"type": "string"}},
+        "refutes": {"type": "array", "items": {"type": "string"}},
+        "similar_to": {"type": "array", "items": {"type": "string"}}
+      },
+      "additionalProperties": false
+    },
+    "source": {
+      "type": "object",
+      "properties": {
+        "url": {"type": "string", "format": "uri"},
+        "author": {"type": "string"},
+        "added_at": {"type": "string", "format": "date"}
+      },
+      "additionalProperties": false
+    },
+    "summary": {"type": "string"},
+    "tags": {"type": "array", "items": {"type": "string"}}
+  },
+  "additionalProperties": false
+}

--- a/kb/example_queries.sql
+++ b/kb/example_queries.sql
@@ -1,0 +1,26 @@
+-- Find patterns about retry and idempotency verified in last 90 days
+SELECT *
+FROM items
+WHERE artifact_type = 'pattern'
+  AND EXISTS (SELECT 1 FROM json_each(tags) WHERE value = 'retry')
+  AND EXISTS (SELECT 1 FROM json_each(tags) WHERE value = 'idempotency')
+  AND stack_cloud = 'vercel'
+  AND maturity IN ('tested','productionized')
+  AND julianday('now') - julianday(last_verified_at) < 90;
+
+-- Retrieve commands to run a specific pattern
+SELECT json_extract(how_to_run, '$') AS commands
+FROM items
+WHERE id = 'pat-serverside-webhooks-v0';
+
+-- Compare evidence between two repos
+SELECT i.id, i.summary, s.url, i.p_conf, i.benchmarks, i.cost_est
+FROM items i
+JOIN sources s ON s.item_id = i.id
+WHERE i.id IN ('repo-a', 'repo-b');
+
+-- Upgrade prompts with draft maturity
+SELECT id, title
+FROM items
+WHERE EXISTS (SELECT 1 FROM json_each(capability) WHERE value = 'evals')
+  AND maturity = 'draft';

--- a/kb/schema.sql
+++ b/kb/schema.sql
@@ -1,0 +1,44 @@
+-- SQLite schema for knowledge base catalog
+CREATE TABLE items (
+  id TEXT PRIMARY KEY,
+  title TEXT NOT NULL,
+  artifact_type TEXT NOT NULL,
+  capability TEXT,          -- JSON array
+  task TEXT,                -- JSON array
+  stack_lang TEXT,
+  stack_runtime TEXT,
+  stack_cloud TEXT,
+  stack_db TEXT,
+  stack_vec TEXT,
+  stack_llm TEXT,
+  maturity TEXT,
+  last_verified_at TEXT,
+  p_conf REAL,
+  benchmarks TEXT,          -- JSON array
+  passes INTEGER,
+  perf_notes TEXT,
+  cost_est TEXT,
+  failure_modes TEXT,       -- JSON array
+  how_to_run TEXT,          -- JSON array
+  deps TEXT,                -- JSON array
+  license TEXT,
+  summary TEXT,
+  tags TEXT                 -- JSON array
+);
+
+CREATE TABLE edges (
+  item_id TEXT NOT NULL,
+  relation TEXT NOT NULL CHECK (
+    relation IN ('depends_on','supersedes','supports','refutes','similar_to')
+  ),
+  target_id TEXT NOT NULL,
+  FOREIGN KEY(item_id) REFERENCES items(id)
+);
+
+CREATE TABLE sources (
+  item_id TEXT PRIMARY KEY,
+  url TEXT,
+  author TEXT,
+  added_at TEXT,
+  FOREIGN KEY(item_id) REFERENCES items(id)
+);


### PR DESCRIPTION
## Summary
- define JSON schema for knowledge base catalog items
- add SQLite schema and example SQL queries

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f503cd548321a2f3fe35775a14ca