### PR TITLE
fix: remove remote fonts for offline build

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,22 +2,7 @@ import type React from "react"
 import type { Metadata } from "next"
 import "./globals.css"
 
-import { cn } from "@/utils/cn"
-import { Inter, JetBrains_Mono } from "next/font/google"
-
 import Header from "@/components/Header"
-
-const inter = Inter({
-  subsets: ["latin"],
-  display: "swap",
-  variable: "--font-inter",
-})
-
-const jetbrainsMono = JetBrains_Mono({
-  subsets: ["latin"],
-  display: "swap",
-  variable: "--font-jetbrains-mono",
-})
 
 export const metadata: Metadata = {
   title: "j4cob - AI Tools Directory",
@@ -32,7 +17,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className="dark">
-      <body className={cn(inter.variable, jetbrainsMono.variable, "group bg-gray-950 text-gray-100")}>
+      <body className="group bg-gray-950 text-gray-100">
         <Header />
         <main className="px-4 py-6 xl:px-16">{children}</main>
       </body>


### PR DESCRIPTION
## Summary
- avoid remote Google Fonts in layout for offline build

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68af539784788321bcea9e9f56e3b479

---
## EntelligenceAI PR Summary 
 This PR removes Google font dependencies from the main layout file.
- Deleted Inter and JetBrains Mono font imports and initialization in `app/layout.tsx`
- Removed font CSS variable usage from `<body>`
- Layout now uses only Tailwind CSS classes for styling 

