### PR TITLE
chore: add auto-auditor and vision policy

### DIFF
--- a/.github/workflows/vision.yml
+++ b/.github/workflows/vision.yml
@@ -1,0 +1,15 @@
+name: vision-check
+on: [push, pull_request, workflow_dispatch, schedule]
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - run: node tools/vision-check.mjs
+      - name: auto-auditor (PR intents)
+        run: node apps/auditor/daemon.mjs --once || true
+      - name: upload report
+        uses: actions/upload-artifact@v4
+        with: { name: vision-report, path: ops/VISION_REPORT.json }

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ Thumbs.db
 # Test files (keep examples but ignore generated)
 test-*.js
 test-*.mjs
+
+ops/INVENTORY.json
+ops/HISTORY_INDEX.jsonl

--- a/apps/auditor/daemon.mjs
+++ b/apps/auditor/daemon.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// Auto-Auditor: watch → check vision → generate diffs → record ledger → emit PR intents.
+// No deps. ESM.
+import fs from "fs"; import path from "path"; import { execSync, spawnSync } from "child_process";
+import { fileURLToPath } from "url";
+import * as fixers from "../../tools/fixers.mjs";
+
+const ROOT = process.cwd(); const r=(...p)=>path.join(ROOT,...p);
+const now = ()=>new Date().toISOString();
+function appendTrace(row){ fs.mkdirSync(r("ops"),{recursive:true}); fs.appendFileSync(r("ops/TRACE.jsonl"), JSON.stringify({ts:now(), ok:true, ...row})+"\n"); }
+function readJSON(p, d){ try { return JSON.parse(fs.readFileSync(r(p),"utf8")); } catch { return d; } }
+
+function runVision() {
+  try {
+    execSync("node tools/vision-check.mjs", { stdio:"inherit" });
+  } catch (_) { /* non-zero on fail is expected */ }
+  const report = readJSON("ops/VISION_REPORT.json", null);
+  if (!report) throw new Error("VISION_REPORT missing. Did vision-check run?");
+  return report;
+}
+
+function applyPatch(patch) {
+  if (!patch) return { ok:false, note:"no patch" };
+  const proc = spawnSync("git", ["apply", "--whitespace=fix", "-"], { input: patch, encoding: "utf8" });
+  return { ok: proc.status === 0, stderr: proc.stderr };
+}
+
+function prIntent(title, diff, branch) {
+  const row = { ts: now(), title, branch, diff };
+  const f = r("state/intents/pr.jsonl");
+  fs.mkdirSync(path.dirname(f), { recursive:true });
+  fs.appendFileSync(f, JSON.stringify(row) + "\n");
+  appendTrace({ phase:"intent", step:"request_pr", ok:true, note:title, extra:{branch} });
+}
+
+function pickFix(item) {
+  const reg = readJSON("policy/fixes.json", {});
+  const cfg = reg[item.id] || reg[item.id.split(" ")[0]]; // tolerate id variants
+  if (!cfg) return null;
+  return cfg;
+}
+
+function buildTitle(item) {
+  const name = item.id.replace(/[:/]/g, " ");
+  return `chore(vision): fix ${name}`;
+}
+
+async function oneShot({ auto=true } = {}) {
+  appendTrace({ phase:"audit", step:"start", ok:true });
+  const report = runVision();
+  const fails = report.items.filter(i=>!i.ok);
+  if (!fails.length) { appendTrace({ phase:"audit", step:"pass", ok:true, note:`score ${report.score}`}); console.log("PASS", report.score); return; }
+
+  for (const it of fails) {
+    const cfg = pickFix(it); if (!cfg) continue;
+    const patch = (fixers[cfg.fixer] || (()=>null))(it.id);
+    if (!patch) continue;
+
+    if (cfg.autoApply && auto) {
+      const res = applyPatch(patch);
+      appendTrace({ phase:"patch", step:it.id, ok:res.ok, note: cfg.fixer });
+      if (!res.ok) prIntent(buildTitle(it), patch, `vision/${Date.now().toString(36)}`);
+    } else {
+      prIntent(buildTitle(it), patch, `vision/${Date.now().toString(36)}`);
+    }
+  }
+  appendTrace({ phase:"audit", step:"done", ok:true, note:`score ${report.score}` });
+}
+
+function main() {
+  const arg = process.argv[2] || "";
+  if (arg === "--once") return oneShot();
+  // daemon: re-run on file changes and hourly
+  console.log("Auto-Auditor running… (Ctrl+C to exit)");
+  setInterval(()=>oneShot().catch(()=>{}), 60*60*1000); // hourly
+  fs.watch(ROOT, { recursive:true }, (e,f)=> {
+    if (!f) return;
+    if (/^ops\/|^state\//.test(f)) return;
+    clearTimeout(global.__t);
+    global.__t = setTimeout(()=>oneShot({auto:false}).catch(()=>{}), 1200); // aggregate burst → PR intents (no auto-apply)
+  });
+}
+main();

--- a/meta/vision.json
+++ b/meta/vision.json
@@ -1,0 +1,27 @@
+{
+  "version": "0.1",
+  "north_star": "Signal density + measurability > complexity.",
+  "required_paths": [
+    "apps/server/server.js",
+    "apps/public/index.html",
+    "apps/public/ui.js",
+    "policy/gamma.json",
+    "policy/cost.json",
+    "ops/TRACE.jsonl",
+    { "anyOf": ["bin/nstar.mjs", "apps/agent/loop.js"] }
+  ],
+  "recommended_paths": [
+    ".github/workflows/vision.yml",
+    "ops/PR_MAP.json",
+    "tools/trace-summary.mjs"
+  ],
+  "must_ignore": ["ops/INVENTORY.json", "ops/HISTORY_INDEX.jsonl"],
+  "rules": {
+    "ledger_single_source": true,
+    "ui_has_catchall_renderer": true,
+    "ci_eval_gate_present": true,
+    "repo_size_kloc_max": 5
+  },
+  "weights": { "hard": 8, "medium": 3, "soft": 1 },
+  "thresholds": { "pass": 85, "warn": 70 }
+}

--- a/policy/fixes.json
+++ b/policy/fixes.json
@@ -1,0 +1,9 @@
+{
+  "ignore:ops/INVENTORY.json": { "fixer": "ensureGitignore", "autoApply": true },
+  "ignore:ops/HISTORY_INDEX.jsonl": { "fixer": "ensureGitignore", "autoApply": true },
+  "rule:gamma_policy": { "fixer": "seedPolicy", "autoApply": true },
+  "rule:cost_policy": { "fixer": "seedPolicy", "autoApply": true },
+  "rule:ci_eval_gate": { "fixer": "addCiEvalGate", "autoApply": false },
+  "rule:ui_catchall": { "fixer": "addUICatchall", "autoApply": false },
+  "req:.gitignore": { "fixer": "ensureGitignore", "autoApply": true }
+}

--- a/tools/fixers.mjs
+++ b/tools/fixers.mjs
@@ -1,0 +1,82 @@
+// ESM fixers: each returns a unified diff string (tiny patch) or null.
+import fs from "fs"; import path from "path";
+const r = (...p)=>path.join(process.cwd(),...p);
+
+export function ensureGitignore(id) {
+  const gi = r(".gitignore");
+  const add = id.startsWith("ignore:") ? id.slice(7) : "ops/INVENTORY.json";
+  const exists = fs.existsSync(gi) ? fs.readFileSync(gi,"utf8").includes(add) : false;
+  if (exists) return null;
+  const before = fs.existsSync(gi) ? fs.readFileSync(gi,"utf8") : "";
+  const after = (before.trimEnd() + "\n" + add + "\n").replace(/\r/g,"");
+  return `*** Begin Patch
+*** Update File: .gitignore
+@@
+-${before.split("\n").join("\n")}
++${after.split("\n").join("\n")}
+*** End Patch
+`;
+}
+
+export function seedPolicy() {
+  const gamma = `{
+  "weights":{"tests_pass":0.40,"retrieval_cited":0.25,"cost_ok":0.20,"diff_tiny":0.15},
+  "thresholds":{"safe":0.60,"fast":0.50,"cheap":0.40}
+}
+`;
+  const cost = `{"per_run_gbp":3.0,"per_day_gbp":25.0}
+`;
+  const files = [];
+  if (!fs.existsSync(r("policy/gamma.json"))) files.push(["policy/gamma.json", gamma]);
+  if (!fs.existsSync(r("policy/cost.json")))  files.push(["policy/cost.json", cost]);
+  if (!files.length) return null;
+
+  let patch = "*** Begin Patch\n";
+  for (const [p,content] of files) {
+    patch += `*** Add File: ${p}\n+${content.split("\n").map(x=>x?x:``).join("\n")}\n`;
+  }
+  patch += "*** End Patch\n";
+  return patch;
+}
+
+export function addCiEvalGate() {
+  const p = ".github/workflows/vision.yml";
+  if (fs.existsSync(r(p))) return null;
+  const y = `name: vision-check
+on: [pull_request, workflow_dispatch]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - run: node tools/vision-check.mjs
+`;
+  return `*** Begin Patch
+*** Add File: ${p}
++${y.split("\n").join("\n")}
+*** End Patch
+`;
+}
+
+export function addUICatchall() {
+  const p = r("apps/public/ui.js"); if (!fs.existsSync(p)) return null;
+  const js = fs.readFileSync(p,"utf8");
+  if (/R\.auto\s*=|registry\.auto\s*=/.test(js)) return null;
+  const after = js.replace(/const R\s*=\s*{/, `const R = {
+  auto: (b) => {
+    const pre = document.createElement('pre');
+    const code = document.createElement('code');
+    code.textContent = typeof b === 'string' ? b : JSON.stringify(b, null, 2);
+    pre.append(code); return pre;
+  },`);
+  if (after === js) return null;
+  return `*** Begin Patch
+*** Update File: apps/public/ui.js
+@@
+-${js.split("\n").join("\n")}
++${after.split("\n").join("\n")}
+*** End Patch
+`;
+}

--- a/tools/vision-check.mjs
+++ b/tools/vision-check.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+// Minimal vision check: reads meta/vision.json and writes ops/VISION_REPORT.json
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+
+const ROOT = process.cwd();
+const r = (...p) => path.join(ROOT, ...p);
+const meta = JSON.parse(fs.readFileSync(r('meta/vision.json'), 'utf8'));
+const report = { items: [] };
+
+function add(id, ok) {
+  report.items.push({ id, ok });
+}
+
+// required paths
+for (const req of meta.required_paths || []) {
+  if (typeof req === 'string') {
+    add(`req:${req}`, fs.existsSync(r(req)));
+  } else if (req.anyOf) {
+    const ok = req.anyOf.some(p => fs.existsSync(r(p)));
+    add(`req:anyOf:${req.anyOf.join('|')}`, ok);
+  }
+}
+
+// must ignore
+const giPath = r('.gitignore');
+const gi = fs.existsSync(giPath) ? fs.readFileSync(giPath, 'utf8') : '';
+for (const ig of meta.must_ignore || []) {
+  add(`ignore:${ig}`, gi.includes(ig));
+}
+
+// rules
+add('rule:gamma_policy', fs.existsSync(r('policy/gamma.json')));
+add('rule:cost_policy', fs.existsSync(r('policy/cost.json')));
+add('rule:ci_eval_gate', fs.existsSync(r('.github/workflows/vision.yml')));
+add('rule:ledger_single_source', fs.existsSync(r('ops/TRACE.jsonl')));
+const uiPath = r('apps/public/ui.js');
+const uiCatch = fs.existsSync(uiPath) && /R\.auto\s*=|registry\.auto\s*=/.test(fs.readFileSync(uiPath, 'utf8'));
+add('rule:ui_catchall', uiCatch);
+
+try {
+  const out = execSync("git ls-files | xargs wc -l | tail -n1 | awk '{print $1}'", { encoding: 'utf8' });
+  const lines = parseInt(out.trim(), 10) || 0;
+  const ok = lines <= (meta.rules?.repo_size_kloc_max || 0) * 1000;
+  add('rule:repo_size_kloc', ok);
+} catch {
+  add('rule:repo_size_kloc', false);
+}
+
+const okCount = report.items.filter(i => i.ok).length;
+report.score = report.items.length ? Math.round((okCount / report.items.length) * 100) : 100;
+
+fs.mkdirSync(r('ops'), { recursive: true });
+fs.writeFileSync(r('ops/VISION_REPORT.json'), JSON.stringify(report, null, 2));
+console.log('score', report.score);


### PR DESCRIPTION
## Summary
- add vision contract and policy fix registry
- wire Auto-Auditor daemon with minimal vision check and fixers
- run vision check in CI and ignore generated ops files

## Testing
- `node apps/auditor/daemon.mjs --once`
- `npm test` *(fails: Cannot find module '/workspace/v0-j4cob/test-streaming.mjs')*

------
https://chatgpt.com/codex/tasks/task_e_68b02b8744c483219752a04c34e134ff

---
## EntelligenceAI PR Summary 
 This PR implements an automated vision compliance system for code quality monitoring and enforcement.
- Added GitHub Actions workflow (.github/workflows/vision.yml) for running automated checks
- Created configuration files (meta/vision.json, policy/fixes.json) defining project standards and fix policies
- Implemented vision-check.mjs to evaluate projects against criteria and generate compliance reports
- Added fixers.mjs with utility functions for automated remediation of common issues
- Created daemon.mjs for continuous monitoring with both one-shot and continuous operation modes
- Implemented logging to TRACE.jsonl for audit purposes 

