### PR TITLE
feat: add streaming chat route and page

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest } from "next/server"
+
+export async function POST(req: NextRequest) {
+  const { message } = await req.json()
+  const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+    },
+    body: JSON.stringify({
+      model: "gpt-3.5-turbo",
+      stream: true,
+      messages: [{ role: "user", content: message }],
+    }),
+  })
+  return new Response(response.body, {
+    headers: { "Content-Type": "text/event-stream" },
+  })
+}

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -1,0 +1,30 @@
+"use client"
+import { useState } from "react"
+
+export default function ChatPage() {
+  const [input, setInput] = useState("")
+  const [log, setLog] = useState("")
+
+  async function send() {
+    const res = await fetch("/api/chat", {
+      method: "POST",
+      body: JSON.stringify({ message: input }),
+    })
+    const reader = res.body?.getReader()
+    if (!reader) return
+    const decoder = new TextDecoder()
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      setLog(t => t + decoder.decode(value))
+    }
+  }
+
+  return (
+    <div>
+      <input value={input} onChange={e => setInput(e.target.value)} />
+      <button onClick={send}>Send</button>
+      <pre>{log}</pre>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add streaming chat API route
- add minimal chat page to consume stream

## Testing
- `pnpm lint` *(fails: "How would you like to configure ESLint?")*

------
https://chatgpt.com/codex/tasks/task_e_68af555b78b88321aabe0eae6517dc41

---
## EntelligenceAI PR Summary 
 This PR adds a complete chat interface with OpenAI integration using Next.js App Router architecture.
- Created server-side API route (`app/api/chat/route.ts`) that handles OpenAI communication with streaming support
- Implemented client-side chat UI (`app/chat/page.tsx`) with real-time message display
- Added proper authentication using environment variables for OpenAI API
- Implemented streaming response handling with ReadableStream and TextDecoder 

